### PR TITLE
Respect database restrictions for target table of collection

### DIFF
--- a/Classes/Collection/StaticRecordCollection.php
+++ b/Classes/Collection/StaticRecordCollection.php
@@ -167,7 +167,6 @@ class StaticRecordCollection extends AbstractRecordCollection implements Editabl
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable(self::getCollectionDatabaseTable());
-        $queryBuilder->getRestrictions()->removeAll();
         $statement = $queryBuilder->select($this->getItemTableName() . '.*')
             ->from(self::getCollectionDatabaseTable())
             ->join(


### PR DESCRIPTION
Keep expectation of user and integrator.
Do not include records,
if they are disabled or not available yet (e.g. starttime).

Resolves: #4